### PR TITLE
Add src to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "SpryrocksCapacitorSocketConnectionPlugin.podspec"
+    "SpryrocksCapacitorSocketConnectionPlugin.podspec",
+    "src/"
   ],
   "author": "Maxim Zhemerenko",
   "license": "MIT",


### PR DESCRIPTION
This is required for upgrading to pnpm v10 as we access modules directly from the src directory

I don't think we need to worry about the failing action. That is from the forked repo and not a concern for us since we install this module directly from GitHub. 