### PR TITLE
Synchronize findSocketByLink read to fix iOS data race

### DIFF
--- a/ios/Plugin/CapacitorSocketConnectionPlugin.swift
+++ b/ios/Plugin/CapacitorSocketConnectionPlugin.swift
@@ -96,10 +96,11 @@ public class CapacitorSocketConnectionPluginPlugin: CAPPlugin, SocketDelegate {
     }
     
     private func findSocketByLink(_ link: NativeLink) throws -> Socket {
-        guard let found = socketsMap.first(where: { s in s.key == link.uuid }) else {
+        let socket = queue.sync { socketsMap[link.uuid] }
+        guard let socket else {
             throw SocketError("Cannot find socket with provided uuid")
         }
-        return found.value
+        return socket
     }
     
     private func success(_ call: CAPPluginCall, _ data: PluginCallResultData = [:]) {


### PR DESCRIPTION
@sethtoles's note: I was running into frequent crashes on startup running the app in the iOS simulator. I gave claude the crash log and the rest is its fix...

## Summary

This is the final piece of an iOS thread-safety fix for `socketsMap` in the Capacitor socket plugin. `main` already serializes the writes (`openConnection`, `removeSocket`) through a dedicated `DispatchQueue`, but the read in `findSocketByLink` was still unsynchronized — a data race against those writes. This change routes the read through the same serial queue.

## Test plan

- No automated tests in this repo for the native iOS plugin. Change is a one-line synchronization fix verified by inspection: the read now uses the same `queue.sync` boundary as the existing writes.
- Recommend a manual smoke test in the consuming app (open/send/close socket connections).

## Monitoring

Low risk — single-statement synchronization change. Watch for any socket connection errors ("Cannot find socket with provided uuid") in app error tracking, which would indicate a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)